### PR TITLE
Disable wrapping from either end of list

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,12 @@ https://github.com/jaiswalshubham84/Flutter-Carousel
         <td>0.5</td>
         <td>Defines the opacity of indicator background</td>
     </tr>
+    <tr>
+        <td>allowWrap</td>
+        <td>bool</td>
+        <td>true</td>
+        <td>Defines if the carousel should wrap once you reach the end or if your at the begining and go left if it should take you to the end</td>
+    </tr>
 </table>
 <br></br>
 

--- a/lib/src/carousel/multi_axis_carousel.dart
+++ b/lib/src/carousel/multi_axis_carousel.dart
@@ -5,8 +5,10 @@ class MultiAxisCarouselState extends StatelessWidget {
   int currentPage;
   bool initial = true;
   final dynamic props;
+  Function updatePosition;
+
   MultiAxisCarouselState(
-    this.props,
+    this.props, this.updatePosition
   ) {
     currentPage = 0;
   }
@@ -26,6 +28,7 @@ class MultiAxisCarouselState extends StatelessWidget {
         scrollDirection: props.axis,
         itemCount: count,
         onPageChanged: (i) {
+          updatePosition(i);
           currentPage = i;
           if (props.onPageChange != null) {
             props.onPageChange(i);

--- a/lib/src/carousel/rotatingcarousel.dart
+++ b/lib/src/carousel/rotatingcarousel.dart
@@ -5,7 +5,9 @@ class RotatingCarouselState extends StatelessWidget {
   int currentPage;
   bool initial = true;
   final dynamic props;
-  RotatingCarouselState(this.props) {
+  Function updatePosition;
+
+  RotatingCarouselState(this.props, this.updatePosition) {
     currentPage = 0;
   }
 
@@ -25,6 +27,7 @@ class RotatingCarouselState extends StatelessWidget {
         controller: props.controller,
         itemCount: count,
         onPageChanged: (i) {
+          updatePosition(i);
           if (props.onPageChange != null) {
             props.onPageChange(i);
           }

--- a/lib/src/carousel/simple_carousel.dart
+++ b/lib/src/carousel/simple_carousel.dart
@@ -6,9 +6,10 @@ class SimpleCarousel extends StatelessWidget {
   int currentPage;
   bool initial = true;
   final dynamic props;
+  Function updatePosition;
 
   SimpleCarousel(
-    this.props,
+    this.props, this.updatePosition
   );
 
   initiate(index) {
@@ -27,6 +28,7 @@ class SimpleCarousel extends StatelessWidget {
         controller: props.controller,
         itemCount: props.children.length,
         onPageChanged: (i) {
+          updatePosition(i);
           currentPage = i;
           if (props.onPageChange != null) {
             props.onPageChange(i);

--- a/lib/src/carousel/slide_swipe.dart
+++ b/lib/src/carousel/slide_swipe.dart
@@ -5,9 +5,10 @@ class SlideSwipe extends StatelessWidget {
   int currentPage;
   bool initial;
   final dynamic props;
+  Function updatePosition;
 
   SlideSwipe(
-    this.props,
+    this.props, this.updatePosition
   );
 
   initiate(index) {
@@ -34,6 +35,7 @@ class SlideSwipe extends StatelessWidget {
         controller: props.controller,
         itemCount: count,
         onPageChanged: (i) {
+          updatePosition(i);
           if (props.onPageChange != null) {
             props.onPageChange(i);
           }

--- a/lib/src/carousel/x_rotating_carousel.dart
+++ b/lib/src/carousel/x_rotating_carousel.dart
@@ -5,9 +5,10 @@ class XcarouselState extends StatelessWidget {
   int currentPage;
   bool initial = true;
   final dynamic props;
+  Function updatePosition;
 
   XcarouselState(
-    this.props,
+    this.props, this.updatePosition,
   ) {
     currentPage = 0;
   }
@@ -28,6 +29,7 @@ class XcarouselState extends StatelessWidget {
         scrollDirection: props.axis,
         itemCount: count,
         onPageChanged: (i) {
+          updatePosition(i);
           if (props.onPageChange != null) {
             props.onPageChange(i);
           }

--- a/lib/src/carousel/zrotatingcarousel.dart
+++ b/lib/src/carousel/zrotatingcarousel.dart
@@ -5,8 +5,10 @@ class ZcarouselState extends StatelessWidget {
   int currentPage;
   bool initial = true;
   final dynamic props;
+  Function updatePosition;
+
   ZcarouselState(
-    this.props,
+    this.props, this.updatePosition,
   ) {
     currentPage = 0;
   }
@@ -27,6 +29,10 @@ class ZcarouselState extends StatelessWidget {
         scrollDirection: props.axis,
         itemCount: count,
         onPageChanged: (i) {
+          updatePosition(i);
+          if (props.onPageChange != null) {
+            props.onPageChange(i);
+          }
           currentPage = i;
         },
         itemBuilder: (context, index) => builder(index));
@@ -59,7 +65,7 @@ class ZcarouselState extends StatelessWidget {
       builder: (context, child) {
         double value = 1.0;
         value = initial
-            ? initiate(index) ?? props.controller1.page - index
+            ? initiate(index) ?? props.controller.page - index
             : value = props.controller.page - index;
         value = (1 - (value.abs() * 0.2)).clamp(0.0, 1.0);
         return new Column(


### PR DESCRIPTION
Added the ability to specify if the carousel should wrap.  The default is to allow as this is the current functionality and is backward compatible.